### PR TITLE
Correct arity mismatch for ex-info

### DIFF
--- a/src/leiningen/set_version.clj
+++ b/src/leiningen/set_version.clj
@@ -126,7 +126,8 @@
   [project type-kw]
   (when-not (#{:major :minor :point} type-kw)
     (throw (ex-info (str "Unknown keyword argument " type-kw ".  "
-                         "Expecting one of :major, :minor or :point."))))
+                         "Expecting one of :major, :minor or :point.")
+                    {:exit-code 1})))
   (let [current (:version project)
         components (version-components current)
         new-components (if (:snapshot components)


### PR DESCRIPTION
I called `lein set-version` incorrectly and this code path was hit. I do this all the time--missing map argument to `ex-info`. Appears to be the only one in the code base.
